### PR TITLE
Feature/di

### DIFF
--- a/AutoNumber/BlobOptimisticDataStore.cs
+++ b/AutoNumber/BlobOptimisticDataStore.cs
@@ -28,7 +28,7 @@ namespace AutoNumber
 
         public BlobOptimisticDataStore(CloudStorageAccount cloudStorageAccount, IOptions<AutoNumberOptions> options)
             : this(cloudStorageAccount, options.Value.StorageContainerName)
-        {      
+        {
         }
 
         public string GetData(string blockName)

--- a/AutoNumber/Extensions/ServiceCollectionExtensions.cs
+++ b/AutoNumber/Extensions/ServiceCollectionExtensions.cs
@@ -35,7 +35,9 @@ namespace AutoNumber
             {
                 CloudStorageAccount storageAccount = null;
 
-                if (options.StorageAccountConnectionString == null)
+                if (options.CloudStorageAccount != null)
+                    storageAccount = options.CloudStorageAccount;
+                else if (options.StorageAccountConnectionString == null)
                     storageAccount = x.GetService<CloudStorageAccount>();
                 else
                     storageAccount = CloudStorageAccount.Parse(options.StorageAccountConnectionString);

--- a/AutoNumber/Extensions/ServiceCollectionExtensions.cs
+++ b/AutoNumber/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using AutoNumber.Interfaces;
 using AutoNumber.Options;
+using Microsoft.Azure.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.WindowsAzure.Storage;
 using System;
 
 namespace AutoNumber

--- a/AutoNumber/Extensions/ServiceCollectionExtensions.cs
+++ b/AutoNumber/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ namespace AutoNumber
     {
         private const string AutoNumber = "AutoNumber";
 
+        [Obsolete("This method is deprecated, please use AddAutoNumber with options builder.", error: false)]
         public static IServiceCollection AddAutoNumber(this IServiceCollection services)
         {
             services.AddOptions<AutoNumberOptions>()

--- a/AutoNumber/Extensions/ServiceCollectionExtensions.cs
+++ b/AutoNumber/Extensions/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace AutoNumber
                     .Configure<IConfiguration>((settings, configuration)
                         => configuration.GetSection(AutoNumber).Bind(settings));
 
-            services.AddScoped<IOptimisticDataStore, BlobOptimisticDataStore>();
+            services.AddSingleton<IOptimisticDataStore, BlobOptimisticDataStore>();
             services.AddSingleton<IUniqueIdGenerator, UniqueIdGenerator>();
 
             return services;

--- a/AutoNumber/Options/AutoNumberOptions.cs
+++ b/AutoNumber/Options/AutoNumberOptions.cs
@@ -1,10 +1,13 @@
-﻿namespace AutoNumber.Options
+﻿using Microsoft.Azure.Storage;
+
+namespace AutoNumber.Options
 {
     public class AutoNumberOptions
     {
         public int BatchSize { get; set; } = 100;
         public int MaxWriteAttempts { get; set; } = 100;
         public string StorageContainerName { get; set; } = "unique-urls";
-        public string StorageAccountConnectionString { get; set; } = null;
+        public string StorageAccountConnectionString { get; set; }
+        public CloudStorageAccount CloudStorageAccount { get; set; }
     }
 }

--- a/AutoNumber/Options/AutoNumberOptions.cs
+++ b/AutoNumber/Options/AutoNumberOptions.cs
@@ -5,5 +5,6 @@
         public int BatchSize { get; set; } = 100;
         public int MaxWriteAttempts { get; set; } = 100;
         public string StorageContainerName { get; set; } = "unique-urls";
+        public string StorageAccountConnectionString { get; set; } = null;
     }
 }

--- a/AutoNumber/Options/AutoNumberOptionsBuilder.cs
+++ b/AutoNumber/Options/AutoNumberOptionsBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Azure.Storage;
+using Microsoft.Extensions.Configuration;
 using System;
 
 namespace AutoNumber.Options
@@ -37,6 +38,14 @@ namespace AutoNumber.Options
 
             Options.StorageAccountConnectionString =
                 _configuration.GetConnectionString(connectionStringOrName) ?? connectionStringOrName;
+
+            return this;
+        }
+
+        public AutoNumberOptionsBuilder UseStorageAccount(CloudStorageAccount storageAccount)
+        {
+            Options.CloudStorageAccount = storageAccount 
+                    ?? throw new ArgumentNullException(nameof(storageAccount));
 
             return this;
         }

--- a/AutoNumber/Options/AutoNumberOptionsBuilder.cs
+++ b/AutoNumber/Options/AutoNumberOptionsBuilder.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+
+namespace AutoNumber.Options
+{
+    public class AutoNumberOptionsBuilder
+    {
+        private readonly IConfiguration _configuration;
+        private const string DefaultContainerName = "unique-urls";
+        private const string AutoNumber = "AutoNumber";
+
+        public AutoNumberOptions Options { get; } = new AutoNumberOptions();
+
+        public AutoNumberOptionsBuilder(IConfiguration configuration)
+        {
+            _configuration = configuration;
+            configuration.GetSection(AutoNumber).Bind(Options);
+        }
+
+        /// <summary>
+        /// Uses the default StorageAccount already defined in dependency injection
+        /// </summary>
+        public AutoNumberOptionsBuilder UseDefaultStorageAccount()
+        {
+            Options.StorageAccountConnectionString = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Uses an Azure StorageAccount connection string to init the blob storage
+        /// </summary>
+        /// <param name="connectionStringOrName"></param>
+        public AutoNumberOptionsBuilder UseStorageAccount(string connectionStringOrName)
+        {
+            if (string.IsNullOrEmpty(connectionStringOrName))
+                throw new ArgumentNullException(nameof(connectionStringOrName));
+
+            Options.StorageAccountConnectionString =
+                _configuration.GetConnectionString(connectionStringOrName) ?? connectionStringOrName;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Default container name to store latest generated id on Azure blob storage
+        /// </summary>
+        public AutoNumberOptionsBuilder UseDefaultContainerName()
+        {
+            Options.StorageContainerName = DefaultContainerName;
+            return this;
+        }
+
+        /// <summary>
+        /// Container name for storing latest generated id on Azure blob storage
+        /// </summary>
+        /// <param name="containerName"></param>
+        public AutoNumberOptionsBuilder UseContainerName(string containerName)
+        {
+            Options.StorageContainerName = containerName;
+            return this;
+        }
+
+        /// <summary>
+        /// Max retrying to generate unique id
+        /// </summary>
+        /// <param name="attempts"></param>
+        public AutoNumberOptionsBuilder SetMaxWriteAttempts(int attempts = 100)
+        {
+            Options.MaxWriteAttempts = attempts;
+            return this;
+        }
+
+        /// <summary>
+        /// BatchSize for id generation, higher the value more losing unused id
+        /// </summary>
+        /// <param name="batchSize"></param>
+        public AutoNumberOptionsBuilder SetBatchSize(int batchSize = 100)
+        {
+            Options.BatchSize = batchSize;
+            return this;
+        }
+    }
+}

--- a/AutoNumber/Options/AutoNumberOptionsBuilder.cs
+++ b/AutoNumber/Options/AutoNumberOptionsBuilder.cs
@@ -44,7 +44,7 @@ namespace AutoNumber.Options
 
         public AutoNumberOptionsBuilder UseStorageAccount(CloudStorageAccount storageAccount)
         {
-            Options.CloudStorageAccount = storageAccount 
+            Options.CloudStorageAccount = storageAccount
                     ?? throw new ArgumentNullException(nameof(storageAccount));
 
             return this;

--- a/AutoNumber/UniqueIdGenerator.cs
+++ b/AutoNumber/UniqueIdGenerator.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace AutoNumber
 {
     /// <summary>
-    /// Generate a new incremental id regards the scope name 
+    /// Generate a new incremental id regards the scope name
     /// </summary>
     public class UniqueIdGenerator : IUniqueIdGenerator
     {
@@ -54,6 +54,13 @@ namespace AutoNumber
             MaxWriteAttempts = options.Value.MaxWriteAttempts;
         }
 
+        public UniqueIdGenerator(IOptimisticDataStore optimisticDataStore, AutoNumberOptions options)
+            : this(optimisticDataStore)
+        {
+            BatchSize = options.BatchSize;
+            MaxWriteAttempts = options.MaxWriteAttempts;
+        }
+
         #endregion
 
         /// <summary>
@@ -90,8 +97,7 @@ namespace AutoNumber
             {
                 var data = optimisticDataStore.GetData(scopeName);
 
-                long nextId;
-                if (!long.TryParse(data, out nextId))
+                if (!long.TryParse(data, out long nextId))
                     throw new UniqueIdGenerationException($"The id seed returned from storage for scope '{scopeName}' was corrupt, and could not be parsed as a long. The data returned was: {data}");
 
                 state.LastId = nextId - 1;

--- a/IntegrationTests/Azure.cs
+++ b/IntegrationTests/Azure.cs
@@ -10,9 +10,9 @@ using AutoNumber.Interfaces;
 namespace IntegrationTests.cs
 {
     [TestFixture]
-    public class Azure : Scenarios<Azure.TestScope>
+    public class Azure : Scenarios<TestScope>
     {
-        readonly CloudStorageAccount storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+        private readonly CloudStorageAccount storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
 
         protected override TestScope BuildTestScope()
         {
@@ -25,39 +25,39 @@ namespace IntegrationTests.cs
             blobOptimisticDataStore.Init().GetAwaiter().GetResult();
             return blobOptimisticDataStore;
         }
+    }
 
-        public sealed class TestScope : ITestScope
+    public sealed class TestScope : ITestScope
+    {
+        private readonly CloudBlobClient blobClient;
+
+        public TestScope(CloudStorageAccount account)
         {
-            readonly CloudBlobClient blobClient;
+            var ticks = DateTime.UtcNow.Ticks;
+            IdScopeName = string.Format("autonumbertest{0}", ticks);
+            ContainerName = string.Format("autonumbertest{0}", ticks);
 
-            public TestScope(CloudStorageAccount account)
+            blobClient = account.CreateCloudBlobClient();
+        }
+
+        public string IdScopeName { get; }
+        public string ContainerName { get; }
+
+        public string ReadCurrentPersistedValue()
+        {
+            var blobContainer = blobClient.GetContainerReference(ContainerName);
+            var blob = blobContainer.GetBlockBlobReference(IdScopeName);
+            using (var stream = new MemoryStream())
             {
-                var ticks = DateTime.UtcNow.Ticks;
-                IdScopeName = string.Format("autonumbertest{0}", ticks);
-                ContainerName = string.Format("autonumbertest{0}", ticks);
-
-                blobClient = account.CreateCloudBlobClient();
+                blob.DownloadToStreamAsync(stream).GetAwaiter().GetResult();
+                return Encoding.UTF8.GetString(stream.ToArray());
             }
+        }
 
-            public string IdScopeName { get; private set; }
-            public string ContainerName { get; private set; }
-
-            public string ReadCurrentPersistedValue()
-            {
-                var blobContainer = blobClient.GetContainerReference(ContainerName);
-                var blob = blobContainer.GetBlockBlobReference(IdScopeName);
-                using (var stream = new MemoryStream())
-                {
-                    blob.DownloadToStreamAsync(stream).GetAwaiter().GetResult();
-                    return Encoding.UTF8.GetString(stream.ToArray());
-                }
-            }
-
-            public void Dispose()
-            {
-                var blobContainer = blobClient.GetContainerReference(ContainerName);
-                blobContainer.DeleteAsync().GetAwaiter().GetResult();
-            }
+        public void Dispose()
+        {
+            var blobContainer = blobClient.GetContainerReference(ContainerName);
+            blobContainer.DeleteAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/IntegrationTests/DependencyInjectionTest.cs
+++ b/IntegrationTests/DependencyInjectionTest.cs
@@ -1,4 +1,5 @@
 ﻿using AutoNumber.Interfaces;
+using AutoNumber.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -30,7 +31,7 @@ namespace AutoNumber.IntegrationTests
         {
             var serviceProvider = GenerateServiceProvider();
 
-            var options = serviceProvider.GetService<IOptions<Options.AutoNumberOptions>>();
+            var options = serviceProvider.GetService<IOptions<AutoNumberOptions>>();
 
             Assert.NotNull(options.Value);
             Assert.AreEqual(25, options.Value.MaxWriteAttempts);
@@ -38,6 +39,54 @@ namespace AutoNumber.IntegrationTests
             Assert.AreEqual("unique-urls", options.Value.StorageContainerName);
         }
 
+        [Test]
+        public void OptionsBuilderShouldGenerateOptions()
+        {
+            var serviceProvider = GenerateServiceProvider();
+            var optionsBuilder = new AutoNumberOptionsBuilder(serviceProvider.GetService<IConfiguration>());
+
+            optionsBuilder.SetBatchSize(5);
+            Assert.AreEqual(5, optionsBuilder.Options.BatchSize);
+
+            optionsBuilder.SetMaxWriteAttempts(10);
+            Assert.AreEqual(10, optionsBuilder.Options.MaxWriteAttempts);
+
+            optionsBuilder.UseDefaultContainerName();
+            Assert.AreEqual("unique-urls", optionsBuilder.Options.StorageContainerName);
+
+            optionsBuilder.UseContainerName("test");
+            Assert.AreEqual("test", optionsBuilder.Options.StorageContainerName);
+
+            optionsBuilder.UseDefaultStorageAccount();
+            Assert.AreEqual(null, optionsBuilder.Options.StorageAccountConnectionString);
+
+            optionsBuilder.UseStorageAccount("test");
+            Assert.AreEqual("test123", optionsBuilder.Options.StorageAccountConnectionString);
+
+            optionsBuilder.UseStorageAccount("test-22");
+            Assert.AreEqual("test-22", optionsBuilder.Options.StorageAccountConnectionString);
+        }
+
+        [Test]
+        public void ShouldResolveUniqueIdGenerator()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(CloudStorageAccount.DevelopmentStorageAccount);
+
+            serviceCollection.AddAutoNumber(Configuration, x =>
+            {
+                return x.UseContainerName("ali")
+                 .UseDefaultStorageAccount()
+                 .SetBatchSize(10)
+                 .SetMaxWriteAttempts(100)
+                 .Options;
+            });
+
+            var service = serviceCollection.BuildServiceProvider()
+                                           .GetService<IUniqueIdGenerator>();
+
+            Assert.NotNull(service);
+        }
 
         private ServiceProvider GenerateServiceProvider()
         {

--- a/IntegrationTests/appsettings.json
+++ b/IntegrationTests/appsettings.json
@@ -3,5 +3,8 @@
     "BatchSize": 50,
     "MaxWriteAttempts": 25,
     "StorageContainerName": "unique-urls"
+  },
+  "ConnectionStrings": {
+    "test": "test123"
   }
 }

--- a/README.md
+++ b/README.md
@@ -30,11 +30,30 @@ var id2 = idGen.NextId("orders");
 ```
 
 ### With Microsoft DI
-The project has an extension method to add it and its dependencies to Microsoft ASP.NET DI. The only caveat is you need to registry type of  `CloudStorageAccount` in DI before registring `AutoNumber`.
+The project has an extension method to add it and its dependencies to Microsoft ASP.NET DI. ~~The only caveat is you need to registry type of  `CloudStorageAccount` in DI before registring `AutoNumber`.~~
+
+
+Use options builder to configure the service, take into account the default settings will read from `appsettings.json`.
+
+```
+services.AddAutoNumber(Configuration, x =>
+{
+	return x.UseContainerName("container-name")
+	 .UseStorageAccount("connection-string-or-connection-string-name")
+   //.UseStorageAccount(cloudStorageAccountInstance)
+	 .SetBatchSize(10)
+	 .SetMaxWriteAttempts(100)
+	 .Options;
+});
+```
+
+
+#### Deprecated way to register the service:
 
 
 ```
 // configure the services
+// you need to register an instane of CloudStorageAccount before using this
 serviceCollection.AddAutoNumber();
 
 // Inject `IUniqueIdGenerator` in constructor


### PR DESCRIPTION
The previous method AddAutoNumber only registers the IUniqueIdGenerator without any customization. The need builder method brings more flexibility.

```
services.AddAutoNumber(Configuration, x =>
{
	return x.UseContainerName("container-name")
	 .UseStorageAccount("connection-string-or-connection-string-name")
	 .SetBatchSize(10)
	 .SetMaxWriteAttempts(100)
	 .Options;
});
```

Resolves #2 