### PR TITLE
Add eTags on read and write operations

### DIFF
--- a/AutoNumber/BlobOptimisticDataStore.cs
+++ b/AutoNumber/BlobOptimisticDataStore.cs
@@ -68,14 +68,14 @@ namespace AutoNumber
             return result == null || result.Value != null;
         }
 
-        public bool TryOptimisticWrite(string blockName, string data, Azure.ETag eTag)
+        public bool TryOptimisticWrite(string blockName, string data, Azure.ETag? eTag)
         {
             var blobReference = GetBlobReference(blockName);
             try
             {
                 var blobRequestCondition = new BlobRequestConditions
                 {
-                    IfMatch = eTag
+                    IfMatch = eTag ?? (blobReference.GetProperties()).Value.ETag
                 };
                 UploadText(
                     blobReference,
@@ -93,14 +93,14 @@ namespace AutoNumber
             return true;
         }
 
-        public async Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag eTag)
+        public async Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag? eTag)
         {
             var blobReference = GetBlobReference(blockName);
             try
             {
                 var blobRequestCondition = new BlobRequestConditions
                 {
-                    IfMatch = eTag
+                    IfMatch = eTag ?? (await blobReference.GetPropertiesAsync()).Value.ETag
                 };
                 await UploadTextAsync(
                     blobReference,

--- a/AutoNumber/DataWrapper.cs
+++ b/AutoNumber/DataWrapper.cs
@@ -1,0 +1,15 @@
+﻿namespace AutoNumber
+{
+    public class DataWrapper
+    {
+        public DataWrapper(string value, Azure.ETag eTag)
+        {
+            Value = value;
+            ETag = eTag;
+        }
+
+        public Azure.ETag ETag { get; private set; }
+
+        public string Value { get; private set; }
+    }
+}

--- a/AutoNumber/DebugOnlyFileDataStore.cs
+++ b/AutoNumber/DebugOnlyFileDataStore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using AutoNumber.Interfaces;
@@ -56,14 +57,25 @@ namespace AutoNumber
             return true;
         }
 
-        public bool TryOptimisticWrite(string blockName, string data, Azure.ETag eTag)
+        public bool TryOptimisticWrite(string blockName, string data, Azure.ETag? eTag)
         {
             var blockPath = Path.Combine(directoryPath, $"{blockName}.txt");
+
+            if (eTag.HasValue)
+            {
+                if(!File.Exists(blockPath)) return false;
+
+                var info = new FileInfo(blockPath);
+                var eTagToCompare = ETag.ForDate(info.LastWriteTimeUtc);
+
+                if (!eTagToCompare.Equals(eTag.Value)) return false;
+            }
+
             File.WriteAllText(blockPath, data);
             return true;
         }
 
-        public Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag eTag)
+        public Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag? eTag)
         {
             throw new NotImplementedException();
         }

--- a/AutoNumber/DebugOnlyFileDataStore.cs
+++ b/AutoNumber/DebugOnlyFileDataStore.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using AutoNumber.Interfaces;
-using Azure;
 
 namespace AutoNumber
 {
-    public class DebugOnlyFileDataStore : IOptimisticDataStore
+    internal class DebugOnlyFileDataStore : IOptimisticDataStore
     {
         private const string SeedValue = "1";
 
@@ -19,7 +16,12 @@ namespace AutoNumber
             this.directoryPath = directoryPath;
         }
 
-        public DataWrapper GetData(string blockName)
+        public string GetData(string blockName)
+        {
+            return GetDataWithConcurrencyCheck(blockName).Value;
+        }
+
+        public DataWrapper GetDataWithConcurrencyCheck(string blockName)
         {
             var blockPath = Path.Combine(directoryPath, $"{blockName}.txt");
             try
@@ -42,7 +44,12 @@ namespace AutoNumber
             }
         }
 
-        public Task<DataWrapper> GetDataAsync(string blockName)
+        public Task<string> GetDataAsync(string blockName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DataWrapper> GetDataWithConcurrencyCheckAsync(string blockName)
         {
             throw new NotImplementedException();
         }
@@ -57,25 +64,35 @@ namespace AutoNumber
             return true;
         }
 
-        public bool TryOptimisticWrite(string blockName, string data, Azure.ETag? eTag)
+        public bool TryOptimisticWrite(string blockName, string data)
+        {
+            return TryOptimisticWriteWithConcurrencyCheck(blockName, data, Azure.ETag.All);
+        }
+
+        public bool TryOptimisticWriteWithConcurrencyCheck(string blockName, string data, Azure.ETag eTag)
         {
             var blockPath = Path.Combine(directoryPath, $"{blockName}.txt");
 
-            if (eTag.HasValue)
-            {
-                if(!File.Exists(blockPath)) return false;
+            if(!File.Exists(blockPath)) return false;
 
+            if (!eTag.Equals(Azure.ETag.All))
+            {
                 var info = new FileInfo(blockPath);
                 var eTagToCompare = ETag.ForDate(info.LastWriteTimeUtc);
 
-                if (!eTagToCompare.Equals(eTag.Value)) return false;
+                if (!eTagToCompare.Equals(eTag)) return false;
             }
 
             File.WriteAllText(blockPath, data);
             return true;
         }
 
-        public Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag? eTag)
+        public Task<bool> TryOptimisticWriteAsync(string blockName, string data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> TryOptimisticWriteWithConcurrencyCheckAsync(string blockName, string data, Azure.ETag eTag)
         {
             throw new NotImplementedException();
         }

--- a/AutoNumber/DebugOnlyFileDataStore.cs
+++ b/AutoNumber/DebugOnlyFileDataStore.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using AutoNumber.Interfaces;
+using Azure;
 
 namespace AutoNumber
 {
@@ -16,12 +18,13 @@ namespace AutoNumber
             this.directoryPath = directoryPath;
         }
 
-        public string GetData(string blockName)
+        public DataWrapper GetData(string blockName)
         {
             var blockPath = Path.Combine(directoryPath, $"{blockName}.txt");
             try
             {
-                return File.ReadAllText(blockPath);
+                var info = new FileInfo(blockPath);
+                return new DataWrapper(File.ReadAllText(blockPath), ETag.ForDate(info.LastWriteTimeUtc));
             }
             catch (FileNotFoundException)
             {
@@ -32,11 +35,13 @@ namespace AutoNumber
                     streamWriter.Write(SeedValue);
                 }
 
-                return SeedValue;
+                var info = new FileInfo(blockPath);
+
+                return new DataWrapper(SeedValue, ETag.ForDate(info.LastWriteTimeUtc));
             }
         }
 
-        public Task<string> GetDataAsync(string blockName)
+        public Task<DataWrapper> GetDataAsync(string blockName)
         {
             throw new NotImplementedException();
         }
@@ -51,14 +56,14 @@ namespace AutoNumber
             return true;
         }
 
-        public bool TryOptimisticWrite(string blockName, string data)
+        public bool TryOptimisticWrite(string blockName, string data, Azure.ETag eTag)
         {
             var blockPath = Path.Combine(directoryPath, $"{blockName}.txt");
             File.WriteAllText(blockPath, data);
             return true;
         }
 
-        public Task<bool> TryOptimisticWriteAsync(string blockName, string data)
+        public Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag eTag)
         {
             throw new NotImplementedException();
         }

--- a/AutoNumber/ETag.cs
+++ b/AutoNumber/ETag.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace AutoNumber
+{
+    internal static class ETag
+    {
+        public static Azure.ETag ForDate(DateTime input)
+        {
+            return new Azure.ETag($"W/\"{input.Ticks}\"");
+        }
+    }
+}

--- a/AutoNumber/Interfaces/IOptimisticDataStore.cs
+++ b/AutoNumber/Interfaces/IOptimisticDataStore.cs
@@ -1,14 +1,28 @@
 ﻿using System.Threading.Tasks;
+using Azure;
 
 namespace AutoNumber.Interfaces
 {
     public interface IOptimisticDataStore
     {
-        string GetData(string blockName);
-        Task<string> GetDataAsync(string blockName);
-        bool TryOptimisticWrite(string blockName, string data);
-        Task<bool> TryOptimisticWriteAsync(string blockName, string data);
+        DataWrapper GetData(string blockName);
+        Task<DataWrapper> GetDataAsync(string blockName);
+        bool TryOptimisticWrite(string blockName, string data, Azure.ETag eTag);
+        Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag eTag);
         Task<bool> InitAsync();
         bool Init();
+    }
+
+    public class DataWrapper
+    {
+        public DataWrapper(string value, Azure.ETag eTag)
+        {
+            Value = value;
+            ETag = eTag;
+        }
+
+        public Azure.ETag ETag { get; private set; }
+
+        public string Value { get; private set; }
     }
 }

--- a/AutoNumber/Interfaces/IOptimisticDataStore.cs
+++ b/AutoNumber/Interfaces/IOptimisticDataStore.cs
@@ -6,24 +6,19 @@ namespace AutoNumber.Interfaces
 {
     public interface IOptimisticDataStore
     {
-        DataWrapper GetData(string blockName);
-        Task<DataWrapper> GetDataAsync(string blockName);
-        bool TryOptimisticWrite(string blockName, string data, Azure.ETag? eTag);
-        Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag? eTag);
+        string GetData(string blockName);
+        DataWrapper GetDataWithConcurrencyCheck(string blockName);
+
+        Task<string> GetDataAsync(string blockName);
+        Task<DataWrapper> GetDataWithConcurrencyCheckAsync(string blockName);
+
+        bool TryOptimisticWrite(string blockName, string data);
+        bool TryOptimisticWriteWithConcurrencyCheck(string blockName, string data, Azure.ETag eTag);
+
+        Task<bool> TryOptimisticWriteAsync(string blockName, string data);
+
+        Task<bool> TryOptimisticWriteWithConcurrencyCheckAsync(string blockName, string data, Azure.ETag eTag);
         Task<bool> InitAsync();
         bool Init();
-    }
-
-    public class DataWrapper
-    {
-        public DataWrapper(string value, Azure.ETag eTag)
-        {
-            Value = value;
-            ETag = eTag;
-        }
-
-        public Azure.ETag ETag { get; private set; }
-
-        public string Value { get; private set; }
     }
 }

--- a/AutoNumber/Interfaces/IOptimisticDataStore.cs
+++ b/AutoNumber/Interfaces/IOptimisticDataStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
 using Azure;
 
 namespace AutoNumber.Interfaces
@@ -7,8 +8,8 @@ namespace AutoNumber.Interfaces
     {
         DataWrapper GetData(string blockName);
         Task<DataWrapper> GetDataAsync(string blockName);
-        bool TryOptimisticWrite(string blockName, string data, Azure.ETag eTag);
-        Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag eTag);
+        bool TryOptimisticWrite(string blockName, string data, Azure.ETag? eTag);
+        Task<bool> TryOptimisticWriteAsync(string blockName, string data, Azure.ETag? eTag);
         Task<bool> InitAsync();
         bool Init();
     }

--- a/AutoNumber/InternalsVisibleTo.cs
+++ b/AutoNumber/InternalsVisibleTo.cs
@@ -3,3 +3,5 @@ using System.IO;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AutoNumber.UnitTests")]
+[assembly: InternalsVisibleTo("AutoNumber.IntegrationTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/AutoNumber/InternalsVisibleTo.cs
+++ b/AutoNumber/InternalsVisibleTo.cs
@@ -1,0 +1,5 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AutoNumber.UnitTests")]

--- a/AutoNumber/UniqueIdGenerator.cs
+++ b/AutoNumber/UniqueIdGenerator.cs
@@ -13,7 +13,7 @@ namespace AutoNumber
     /// <summary>
     ///     Generate a new incremental id regards the scope name
     /// </summary>
-    public class UniqueIdGenerator : IUniqueIdGenerator
+    internal class UniqueIdGenerator : IUniqueIdGenerator
     {
         /// <summary>
         ///     Generate a new incremental id regards the scope name
@@ -47,7 +47,7 @@ namespace AutoNumber
 
             while (writesAttempted < MaxWriteAttempts)
             {
-                var data = optimisticDataStore.GetData(scopeName);
+                var data = optimisticDataStore.GetDataWithConcurrencyCheck(scopeName);
 
                 if (!long.TryParse(data.Value, out var nextId))
                     throw new UniqueIdGenerationException(
@@ -57,7 +57,7 @@ namespace AutoNumber
                 state.HighestIdAvailableInBatch = nextId - 1 + BatchSize;
                 var firstIdInNextBatch = state.HighestIdAvailableInBatch + 1;
 
-                if (optimisticDataStore.TryOptimisticWrite(scopeName,
+                if (optimisticDataStore.TryOptimisticWriteWithConcurrencyCheck(scopeName,
                     firstIdInNextBatch.ToString(CultureInfo.InvariantCulture), data.ETag))
                     return;
 

--- a/AutoNumber/UniqueIdGenerator.cs
+++ b/AutoNumber/UniqueIdGenerator.cs
@@ -49,7 +49,7 @@ namespace AutoNumber
             {
                 var data = optimisticDataStore.GetData(scopeName);
 
-                if (!long.TryParse(data, out var nextId))
+                if (!long.TryParse(data.Value, out var nextId))
                     throw new UniqueIdGenerationException(
                         $"The id seed returned from storage for scope '{scopeName}' was corrupt, and could not be parsed as a long. The data returned was: {data}");
 
@@ -58,7 +58,7 @@ namespace AutoNumber
                 var firstIdInNextBatch = state.HighestIdAvailableInBatch + 1;
 
                 if (optimisticDataStore.TryOptimisticWrite(scopeName,
-                    firstIdInNextBatch.ToString(CultureInfo.InvariantCulture)))
+                    firstIdInNextBatch.ToString(CultureInfo.InvariantCulture), data.ETag))
                     return;
 
                 writesAttempted++;

--- a/IntegrationTests/Azure.cs
+++ b/IntegrationTests/Azure.cs
@@ -7,19 +7,19 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using NUnit.Framework;
 
-namespace IntegrationTests.cs
+namespace AutoNumber.IntegrationTests
 {
     [TestFixture]
     public class Azure : Scenarios<TestScope>
     {
         private readonly BlobServiceClient blobServiceClient = new BlobServiceClient("UseDevelopmentStorage=true");
 
-        protected override TestScope BuildTestScope()
+        internal override TestScope BuildTestScope()
         {
             return new TestScope(new BlobServiceClient("UseDevelopmentStorage=true"));
         }
 
-        protected override IOptimisticDataStore BuildStore(TestScope scope)
+        internal override IOptimisticDataStore BuildStore(TestScope scope)
         {
             var blobOptimisticDataStore = new BlobOptimisticDataStore(blobServiceClient, scope.ContainerName);
             blobOptimisticDataStore.Init();

--- a/IntegrationTests/File.cs
+++ b/IntegrationTests/File.cs
@@ -4,17 +4,17 @@ using AutoNumber;
 using AutoNumber.Interfaces;
 using NUnit.Framework;
 
-namespace IntegrationTests.cs
+namespace AutoNumber.IntegrationTests
 {
     [TestFixture]
     public class File : Scenarios<File.TestScope>
     {
-        protected override TestScope BuildTestScope()
+        internal override TestScope BuildTestScope()
         {
             return new TestScope();
         }
 
-        protected override IOptimisticDataStore BuildStore(TestScope scope)
+        internal override IOptimisticDataStore BuildStore(TestScope scope)
         {
             return new DebugOnlyFileDataStore(scope.DirectoryPath);
         }

--- a/IntegrationTests/ITestScope.cs
+++ b/IntegrationTests/ITestScope.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace IntegrationTests.cs
+namespace AutoNumber.IntegrationTests
 {
     public interface ITestScope : IDisposable
     {

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
-    <RootNamespace>IntegrationTests.cs</RootNamespace>
-    <AssemblyName>IntegrationTests.cs</AssemblyName>
+    <RootNamespace>AutoNumber.IntegrationTests</RootNamespace>
+    <AssemblyName>AutoNumber.IntegrationTests</AssemblyName>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <AssemblyTitle>IntegrationTests.cs</AssemblyTitle>
     <Company>Microsoft</Company>

--- a/IntegrationTests/Scenarios.cs
+++ b/IntegrationTests/Scenarios.cs
@@ -6,12 +6,12 @@ using AutoNumber;
 using AutoNumber.Interfaces;
 using NUnit.Framework;
 
-namespace IntegrationTests.cs
+namespace AutoNumber.IntegrationTests
 {
     public abstract class Scenarios<TTestScope> where TTestScope : ITestScope
     {
-        protected abstract IOptimisticDataStore BuildStore(TTestScope scope);
-        protected abstract TTestScope BuildTestScope();
+        internal abstract IOptimisticDataStore BuildStore(TTestScope scope);
+        internal abstract TTestScope BuildTestScope();
 
         [Test]
         public void ShouldReturnOneForFirstIdInNewScope()

--- a/UnitTests/UniqueIdGeneratorTest.cs
+++ b/UnitTests/UniqueIdGeneratorTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AutoNumber.Exceptions;
 using AutoNumber.Interfaces;
+using Azure;
 using NSubstitute;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -48,9 +49,14 @@ namespace AutoNumber.UnitTests
         [Test]
         public void NextIdShouldReturnNumbersSequentially()
         {
+            var eTagDate = new DateTime(2000, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns("0", "250");
-            store.TryOptimisticWrite("test", "3").Returns(true);
+            store.GetData("test")
+                .Returns(
+                    new DataWrapper("0", ETag.ForDate(eTagDate)),
+                    new DataWrapper("250", ETag.ForDate(eTagDate.AddMonths(1))));
+            store.TryOptimisticWrite("test", "3", ETag.ForDate(eTagDate))
+                .Returns(true);
 
             var subject = new UniqueIdGenerator(store)
             {
@@ -65,10 +71,14 @@ namespace AutoNumber.UnitTests
         [Test]
         public void NextIdShouldRollOverToNewBlockWhenCurrentBlockIsExhausted()
         {
+            var eTagDate = new DateTime(2000, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            var eTagDate2 = eTagDate.AddMonths(1);
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns("0", "250");
-            store.TryOptimisticWrite("test", "3").Returns(true);
-            store.TryOptimisticWrite("test", "253").Returns(true);
+            store.GetData("test").Returns(
+                new DataWrapper("0", ETag.ForDate(eTagDate)),
+                new DataWrapper("250", ETag.ForDate(eTagDate2)));
+            store.TryOptimisticWrite("test", "3", ETag.ForDate(eTagDate)).Returns(true);
+            store.TryOptimisticWrite("test", "253", ETag.ForDate(eTagDate2)).Returns(true);
 
             var subject = new UniqueIdGenerator(store)
             {
@@ -87,7 +97,7 @@ namespace AutoNumber.UnitTests
         public void NextIdShouldThrowExceptionOnCorruptData()
         {
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns("abc");
+            store.GetData("test").Returns(new DataWrapper("abc", Azure.ETag.All));
 
             Assert.That(() =>
                 {
@@ -101,7 +111,7 @@ namespace AutoNumber.UnitTests
         public void NextIdShouldThrowExceptionOnNullData()
         {
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns((string) null);
+            store.GetData("test").Returns(new DataWrapper((string)null, Azure.ETag.All));
 
             Assert.That(() =>
                 {
@@ -114,9 +124,11 @@ namespace AutoNumber.UnitTests
         [Test]
         public void NextIdShouldThrowExceptionWhenRetriesAreExhausted()
         {
+            var eTagDate = new DateTime(2000, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns("0");
-            store.TryOptimisticWrite("test", "3").Returns(false, false, false, true);
+            store.GetData("test").Returns(new DataWrapper("0", ETag.ForDate(eTagDate)));
+            store.TryOptimisticWrite("test", "3", ETag.ForDate(eTagDate.AddMonths(1)))
+                .Returns(false, false, false, true);
 
             var generator = new UniqueIdGenerator(store)
             {

--- a/UnitTests/UniqueIdGeneratorTest.cs
+++ b/UnitTests/UniqueIdGeneratorTest.cs
@@ -51,11 +51,11 @@ namespace AutoNumber.UnitTests
         {
             var eTagDate = new DateTime(2000, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test")
+            store.GetDataWithConcurrencyCheck("test")
                 .Returns(
                     new DataWrapper("0", ETag.ForDate(eTagDate)),
                     new DataWrapper("250", ETag.ForDate(eTagDate.AddMonths(1))));
-            store.TryOptimisticWrite("test", "3", ETag.ForDate(eTagDate))
+            store.TryOptimisticWriteWithConcurrencyCheck("test", "3", ETag.ForDate(eTagDate))
                 .Returns(true);
 
             var subject = new UniqueIdGenerator(store)
@@ -74,11 +74,11 @@ namespace AutoNumber.UnitTests
             var eTagDate = new DateTime(2000, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
             var eTagDate2 = eTagDate.AddMonths(1);
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns(
+            store.GetDataWithConcurrencyCheck("test").Returns(
                 new DataWrapper("0", ETag.ForDate(eTagDate)),
                 new DataWrapper("250", ETag.ForDate(eTagDate2)));
-            store.TryOptimisticWrite("test", "3", ETag.ForDate(eTagDate)).Returns(true);
-            store.TryOptimisticWrite("test", "253", ETag.ForDate(eTagDate2)).Returns(true);
+            store.TryOptimisticWriteWithConcurrencyCheck("test", "3", ETag.ForDate(eTagDate)).Returns(true);
+            store.TryOptimisticWriteWithConcurrencyCheck("test", "253", ETag.ForDate(eTagDate2)).Returns(true);
 
             var subject = new UniqueIdGenerator(store)
             {
@@ -97,7 +97,7 @@ namespace AutoNumber.UnitTests
         public void NextIdShouldThrowExceptionOnCorruptData()
         {
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns(new DataWrapper("abc", Azure.ETag.All));
+            store.GetDataWithConcurrencyCheck("test").Returns(new DataWrapper("abc", Azure.ETag.All));
 
             Assert.That(() =>
                 {
@@ -111,7 +111,7 @@ namespace AutoNumber.UnitTests
         public void NextIdShouldThrowExceptionOnNullData()
         {
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns(new DataWrapper((string)null, Azure.ETag.All));
+            store.GetDataWithConcurrencyCheck("test").Returns(new DataWrapper((string)null, Azure.ETag.All));
 
             Assert.That(() =>
                 {
@@ -126,8 +126,8 @@ namespace AutoNumber.UnitTests
         {
             var eTagDate = new DateTime(2000, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
             var store = Substitute.For<IOptimisticDataStore>();
-            store.GetData("test").Returns(new DataWrapper("0", ETag.ForDate(eTagDate)));
-            store.TryOptimisticWrite("test", "3", ETag.ForDate(eTagDate.AddMonths(1)))
+            store.GetDataWithConcurrencyCheck("test").Returns(new DataWrapper("0", ETag.ForDate(eTagDate)));
+            store.TryOptimisticWriteWithConcurrencyCheck("test", "3", ETag.ForDate(eTagDate.AddMonths(1)))
                 .Returns(false, false, false, true);
 
             var generator = new UniqueIdGenerator(store)


### PR DESCRIPTION
Add eTags on read and write operations to guard against concurrency over different instances